### PR TITLE
Add crdt-merge — CRDT-powered merge library for DataFrames, JSON & ML models

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ A collection of awesome CRDT resources
 - [Akka CRDT: An Eventually Consistent REST/JSON database using CRDTs, Akka Cluster and LevelDB](https://github.com/jboner/akka-crdt)
 - [Akka Distributed Data](https://doc.akka.io/docs/akka/snapshot/distributed-data.html?language=scala)
 - [wurmloch-crdt: Experimental implementations of conflict-free replicated data types (CRDTs) for the JVM](https://github.com/netopyr/wurmloch-crdt)
+- [crdt-merge](https://github.com/mgillr/crdt-merge) - Conflict-free merge for DataFrames, JSON, ML models & distributed agents — powered by CRDTs.
 
 #### Toy Implementations
 


### PR DESCRIPTION
## Add crdt-merge

[crdt-merge](https://github.com/mgillr/crdt-merge) is a Python library that brings CRDT (Conflict-free Replicated Data Type) guarantees to data merging — covering DataFrames, JSON, ML model weights, and distributed agent state.

### Key features:
- **Mathematical guarantees**: Every merge is commutative, associative, and idempotent
- **25 merge strategies** including SLERP, TIES, DARE, Fisher merge, and task arithmetic
- **LoRA adapter merging** with rank harmonization
- **Federated learning** support (FedAvg, FedProx)
- **2,600+ tests passing**
- **pip installable**: `pip install crdt-merge`

Thank you for considering this addition!
