### PR TITLE
Add Velt to Implementations > Data Structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ A collection of awesome CRDT resources
 - [Akka CRDT: An Eventually Consistent REST/JSON database using CRDTs, Akka Cluster and LevelDB](https://github.com/jboner/akka-crdt)
 - [Akka Distributed Data](https://doc.akka.io/docs/akka/snapshot/distributed-data.html?language=scala)
 - [wurmloch-crdt: Experimental implementations of conflict-free replicated data types (CRDTs) for the JVM](https://github.com/netopyr/wurmloch-crdt)
+- [Velt: collaboration SDK providing Yjs-based CRDT stores (array, map, text, XML) with hosted sync, presence and offline editing](https://velt.dev)
 
 #### Toy Implementations
 


### PR DESCRIPTION
Adds **Velt** to Implementations → Data Structures.

Velt is a collaboration SDK built on **Yjs** that provides CRDT stores (array, map, text, XML) with hosted sync, presence, and offline editing — sitting alongside the existing Yjs/Automerge entries.

- Site: https://velt.dev
- CRDT docs: https://velt.dev/docs/realtime-collaboration/crdt/overview

Single entry appended to the Data Structures list, matching the `- [Name: description](url)` format.