### PR TITLE
Add Artel (CRDT-based memory replication)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ A collection of awesome CRDT resources
 - [Swarm: JavaScript replicated model (M of MVC) library](https://github.com/gritzko/swarm)
 - [Datanet: an open source CRDT based data synchronization system](http://datanet.co/)
 - [Kuhirō: The Near Cloud](https://www.kuhiro.com)
+- [Artel: CRDT-based memory replication across self-hosted instances over JSON Feed, no central coordinator](https://github.com/NicolasPrimeau/artel)
 
 ### Productivity
 


### PR DESCRIPTION
Adds [Artel](https://github.com/NicolasPrimeau/artel) under Databases and Logs. It's a self-hosted server whose memory store replicates across instances as a CRDT — last-writer-wins on a version counter, tombstone deletes, idempotent commutative merge — using JSON Feed as the transport, with no central coordinator.